### PR TITLE
Removed call to console.log when parsing dates in the header.

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -42,7 +42,6 @@
 
     Header.prototype.parseDate = function(buffer) {
       var day, month, year;
-      console.log(this.convertBinaryToInteger(buffer.slice(0, 1)));
       year = 1900 + this.convertBinaryToInteger(buffer.slice(0, 1));
       month = (this.convertBinaryToInteger(buffer.slice(1, 2))) - 1;
       day = this.convertBinaryToInteger(buffer.slice(2, 3));


### PR DESCRIPTION
`Header.prototype.parseDate()` has an unnecessary call to `console.log()`. It was probably for testing and isn't required in the actual release.

If it's helpful, take a look at the [grunt-remove-logging](https://npmjs.org/package/grunt-remove-logging) Grunt plugin.
