### PR TITLE
CLI tool: input file should be relative to cwd

### DIFF
--- a/bin/node-dbf-convert.js
+++ b/bin/node-dbf-convert.js
@@ -13,7 +13,7 @@ program
   .option('-f, --format <format>', 'Output format (default = csv)', /^(csv)$/i, 'csv')
   .option('-d, --delimiter <delimiter>', 'Field delimiter (default = ,)', ',')
   .option('-q, --quote <quote>', 'Field value wrapper quote (default = ")', '"')
-  .action(function(f) { file = path.join(__dirname, '../', f); })
+  .action(function(f) { file = path.resolve(process.cwd(), f); })
   .parse(process.argv);
 
 var delimiter = program.delimiter || ',';


### PR DESCRIPTION
Previously, CLI tool would resolve the input file path relative to the install location of the script.

For example:

```
$ node-dbf convert ./geo.dbf
> Error: ENOENT: no such file or directory, open '/Users/eschwartz/.nvm/versions/node/v4.2.1/lib/node_modules/node-dbf/geo.dbf'
```

Even absolute paths wouldn't work:

```
$ node-dbf convert `pwd`/geo.dbf
> Error: ENOENT: no such file or directory, open '/Users/eschwartz/.nvm/versions/node/v4.2.1/lib/node_modules/node-dbf/Users/eschwartz/my/working/dir/geo.dbf'
```