### PR TITLE
Read only the necessary bytes when parsing the header

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -8,24 +8,42 @@ export default class Header {
     }
 
     parse(callback) {
-        fs.readFile(this.filename, (err, buffer) => {
+        fs.open(this.filename, 'r', (err, fd) => {
             if (err) throw err;
 
-            this.type = buffer.slice(0, 1).toString(this.encoding);
-            this.dateUpdated = this.parseDate(buffer.slice(1, 4));
-            this.numberOfRecords = this.convertBinaryToInteger(buffer.slice(4, 8));
-            this.start = this.convertBinaryToInteger(buffer.slice(8, 10));
-            this.recordLength = this.convertBinaryToInteger(buffer.slice(10, 12));
+            const startBuffer = Buffer.alloc(2);
 
-            const result = [];
-            for (let i = 32, end = this.start - 32; i <= end; i += 32) {
-                result.push(buffer.slice(i, i+32));
-            }
+            fs.read(fd, startBuffer, 0, 2, 8, (err, bytesRead, buffer) => {
+                if (err) throw err;
 
-            this.fields = result.map(this.parseFieldSubRecord.bind(this));
+                const start = this.convertBinaryToInteger(buffer);
 
-            callback(this);
-        });
+                const headerBuffer = Buffer.alloc(start);
+
+                fs.read(fd, headerBuffer, 0, start, 0, (err, bytesRead, buffer) => {
+                    if (err) throw err;
+
+                    this.type = buffer.slice(0, 1).toString(this.encoding);
+                    this.dateUpdated = this.parseDate(buffer.slice(1, 4));
+                    this.numberOfRecords = this.convertBinaryToInteger(buffer.slice(4, 8));
+                    this.start = this.convertBinaryToInteger(buffer.slice(8, 10));
+                    this.recordLength = this.convertBinaryToInteger(buffer.slice(10, 12));
+
+                    const result = [];
+                    for (let i = 32, end = this.start - 32; i <= end; i += 32) {
+                        result.push(buffer.slice(i, i+32));
+                    }
+
+                    this.fields = result.map(this.parseFieldSubRecord.bind(this));
+
+                    callback(this);
+
+                    fs.close(fd, err => {
+                        if (err) throw err;
+                    })
+                })
+            })
+        })
     }
 
     parseDate(buffer) {


### PR DESCRIPTION
I use this library in a project i'm currently working on. It works beautifully, thank you very much!

The files i use it on are around 1.5GB. The streaming of the body is super cool, however, i noticed that to parse the header, the entire file was being read in memory

This is due to the use of `fs.readFile` in `src/header.js`\
In this PR, the code is a bit lower-level to be able to read only the necessary bytes. The idea is:
1) read on the file only the `start` field of the header, 
2) this information is used to know how many bytes the header is composed of, so only this number of bytes is read

I'm happy to discuss the change further if what i did here is unclear or if it doesn't adhere to the project standard